### PR TITLE
Fix Ember.$ vs. jQuery ambiguity in mixins/base.js

### DIFF
--- a/addon/mixins/base.js
+++ b/addon/mixins/base.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Semantic from '../semantic';
-import $ from 'jquery';
+import jQuery from 'jquery';
 
 const EMBER_ATTRS = ['class', 'classNameBindings', 'classNames', 'tagName'];
 const HTML_ATTRS = ['id', 'name', 'readonly', 'autofocus', 'tabindex', 'title'];
@@ -117,7 +117,7 @@ Semantic.BaseMixin = Ember.Mixin.create({
       return;
     }
     let moduleName = this.getSemanticModuleName();
-    return $.fn[moduleName];
+    return jQuery.fn[moduleName];
   },
 
   willInitSemantic(settings) { // eslint-disable-line no-unused-vars


### PR DESCRIPTION
The latest changes, those for making the annoying warning `Using Ember.$() has been deprecated...` disappear, seem to be insufficient in some cases.

On "certain" occasions (it would be really hard to make a proper minimal example!) Ember vendor-asset compilation evaluates the `$` imported by `addon/mixins/base.js` as being (mistakenly) `Ember.$`, instead of "jQuery". The result is yet another plethora of warnings for almost every ember test cae!

Simple solution: import `jQuery` instead of `$` :relaxed: 